### PR TITLE
Locale numbers

### DIFF
--- a/qml/About.qml
+++ b/qml/About.qml
@@ -63,7 +63,7 @@ Page {
         linkColor: UbuntuColors.orange
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-        text: i18n.tr("Version: ") + "1.0.5"
+        text: i18n.tr("Version %1").arg(Qt.application.version)
       }
 
       Label {

--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -170,7 +170,8 @@ Page {
           aspect: UbuntuShape.DropShadow
         }
         title.text: date
-        subtitle.text: "Steps: " + steps + " Distance: " + distance + " m" + " "
+        subtitle.text: i18n.tr("Steps: %1").arg(steps.toLocaleString(Qt.locale(),"f",0)) + " " + i18n.tr("Distance: %1 m").arg(distance.toLocaleString(Qt.locale(),"f",1))
+
         ProportionalShape {
           SlotsLayout.position: SlotsLayout.Trailing
           source: Image { source: "../Images/trophy.svg" }


### PR DESCRIPTION
This PR will apply locale number format to steps and distances. So e.g. for German 1.005,7 m will be used instead of 1005.7 m in English notation.

This PR is based upon #16 , only merge after that.