### PR TITLE
use Qt slider component and add descriptive labels

### DIFF
--- a/po/steps.jranaraki.pot
+++ b/po/steps.jranaraki.pot
@@ -92,3 +92,6 @@ msgstr ""
 #: ../qml/Setting.qml:141
 msgid "Weight (kg)"
 msgstr ""
+#: ../qml/Setting.qml:196
+msgid "Sensitivity (7-12)"
+msgstr ""

--- a/qml/Setting.qml
+++ b/qml/Setting.qml
@@ -193,7 +193,7 @@ Page {
       divider.visible: false
       Label {
         id: sensitivitylabel
-        text: i18n.tr("Sensitivity")
+        text: i18n.tr("Sensitivity (7-12)")
         anchors {
           top: parent.top; topMargin: mSpacing
         }
@@ -204,19 +204,14 @@ Page {
           top: sensitivitylabel.bottom
           topMargin: mSpacing
           left: parent.left
-          leftMargin: mSpacing*2
+          leftMargin: mSpacing
           right: parent.right
-          rightMargin: mSpacing*2
+          rightMargin: mSpacing*3
         }
         Label {
             id: valueLabel
             text: sensitivitySlider.value.toLocaleString(Qt.locale(),"f",2)
             width: units.gu(7)
-        }
-        Label {
-            id: minLabel
-            text: "7"
-            width: units.gu(2)
         }
         QT.Slider {
           id: sensitivitySlider
@@ -227,14 +222,9 @@ Page {
           live: true
           handle.height: units.gu(2)
           handle.width: handle.height
-          width: parent.width - units.gu(11)
+          width: parent.width - units.gu(7)
           anchors.verticalCenter: parent.verticalCenter
           onMoved: console.log("sensitivity: " + sensitivityValue)
-        }
-        Label {
-            id: maxLabel
-            text: "12"
-            width: units.gu(2)
         }
       }
     }

--- a/qml/Setting.qml
+++ b/qml/Setting.qml
@@ -15,6 +15,7 @@
 */
 
 import QtQuick 2.4
+import QtQuick.Controls 2.5 as QT
 import Ubuntu.Components 1.3
 
 Page {
@@ -198,17 +199,42 @@ Page {
         }
       }
 
-      Slider {
-        id: sensitivitySlider
-        minimumValue: 1.0
-        maximumValue: 10.0
-        live: true
-        width: parent.width
-        anchors {
-          top: sensitivitylabel.bottom; topMargin: mSpacing
+      Row {
+        anchors{
+          top: sensitivitylabel.bottom
+          topMargin: mSpacing
+          left: parent.left
+          leftMargin: mSpacing*2
+          right: parent.right
+          rightMargin: mSpacing*2
         }
-        function formatValue(val) {
-          return val.toFixed(1)
+        Label {
+            id: valueLabel
+            text: sensitivitySlider.value.toLocaleString(Qt.locale(),"f",2)
+            width: units.gu(7)
+        }
+        Label {
+            id: minLabel
+            text: "7"
+            width: units.gu(2)
+        }
+        QT.Slider {
+          id: sensitivitySlider
+          from: 7.0
+          to: 12.0
+          stepSize: 0.25
+          snapMode: Slider.SnapAlways
+          live: true
+          handle.height: units.gu(2)
+          handle.width: handle.height
+          width: parent.width - units.gu(11)
+          anchors.verticalCenter: parent.verticalCenter
+          onMoved: console.log("sensitivity: " + sensitivityValue)
+        }
+        Label {
+            id: maxLabel
+            text: "12"
+            width: units.gu(2)
         }
       }
     }


### PR DESCRIPTION
This PR will change the slider to the Qt slider component. That allows snapping to values and therefore - I think - improves selection of values. I also added some labels to show the current value and min + max values. I restricted the range to 7-12 with steps of 0.25 which I think is sufficient.

This PR is based on current main branch. It might conflict with my other PR's, so then I may need to rebase them.

![screenshot20211102_164411126](https://user-images.githubusercontent.com/37637312/139941155-95384674-505b-4c1d-81e5-6d029877b21f.png)
